### PR TITLE
fixed 'Q to exit' doing 'exit 0' directly

### DIFF
--- a/get-choice.sh
+++ b/get-choice.sh
@@ -382,7 +382,7 @@ function getChoice {
           echo ""
           echo "Quit..."
           showCursor
-          exit 0
+          $returnOrExit 0
           ;;
         *)
           if [[ $showHeader = true ]]; then addend=1; else addend=0; fi


### PR DESCRIPTION
fixed pressing 'Q to exit' would 'exit 0' directly instead of '$returnOrExit 0'